### PR TITLE
Decrease frequency of duplicated boosts

### DIFF
--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -12,7 +12,7 @@ class FeedManager
   # Number of items in the feed since last reblog of status
   # before the new reblog will be inserted. Must be <= MAX_ITEMS
   # or the tracking sets will grow forever
-  REBLOG_FALLOFF = 40
+  REBLOG_FALLOFF = 400
 
   # Execute block for every active account
   # @yield [Account]


### PR DESCRIPTION
Dear Kody,

I see duplicated boosts in my timeline with too much frequency. The people I follow tend to boost the same content over and over, and I'm getting mad. This change would reduce the frequency of such duplicated boosts (from 40 posts in between to 400). Technically you can increase it up to 800 (MAX_ITEMS value), but I think a x10 increase will be enough to preserve my mental wellbeing.

Regards, Roboron.